### PR TITLE
Two possible solutions for the gcc issue

### DIFF
--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir
 cd ImageMagick6/
-./configure  LDFLAGS="-all-static" --prefix=$prefix --host=$target --disable-openmp --disable-install --disable-dependency-tracking --without-frozenpaths --without-perl
+./configure  LDFLAGS="-all-static" --prefix=$prefix --host=$target --without-magick-plus-plus --without-x --disable-openmp --disable-installed --disable-dependency-tracking --without-frozenpaths --without-perl
 make -j${ncore}
 make install
 

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir
 cd ImageMagick6/
-./configure  LDFLAGS="-all-static" --prefix=$prefix --host=$target --without-magick-plus-plus --without-x --disable-openmp --disable-installed --disable-dependency-tracking --without-frozenpaths --without-perl
+./configure --prefix=$prefix --host=$target --without-magick-plus-plus --without-x --disable-openmp --disable-installed --disable-dependency-tracking --without-frozenpaths --without-perl
 make -j${ncore}
 make install
 

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -13,7 +13,7 @@ sources = [
 script = raw"""
 cd $WORKSPACE/srcdir
 cd ImageMagick6/
-./configure --prefix=$prefix --host=$target --without-magick-plus-plus --without-x --disable-openmp --disable-installed --disable-dependency-tracking --without-frozenpaths --without-perl
+./configure --prefix=$prefix --host=$target --without-x --disable-openmp --disable-installed --disable-dependency-tracking --without-frozenpaths --without-perl
 make -j${ncore}
 make install
 


### PR DESCRIPTION
I have a shell-script based solution that is a huge hack and a more reasonable solution that simply removes -all-static. I'm going to test with Travis first, though, because I'm doubtful BinaryBuilder will work on NixOS.